### PR TITLE
don't do anything on save if we can't save existing packfile

### DIFF
--- a/CommonControls/BaseDialogs/MathViews/DoubleViewModel.cs
+++ b/CommonControls/BaseDialogs/MathViews/DoubleViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using CommonControls.Common;
 using System;
+using System.Globalization;
 
 namespace CommonControls.MathViews
 {
@@ -34,7 +35,7 @@ namespace CommonControls.MathViews
         {
             get
             {
-                var valid = double.TryParse(_textvalue, out double result);
+                var valid = double.TryParse(_textvalue.Replace(',', '.'), NumberStyles.Any, CultureInfo.InvariantCulture, out double result);
                 if (valid)
                     return result;
                 return 0;

--- a/CommonControls/Common/DirectoryHelper.cs
+++ b/CommonControls/Common/DirectoryHelper.cs
@@ -24,5 +24,21 @@ namespace CommonControls.Common
             if (!Directory.Exists(path))
                 Directory.CreateDirectory(path);
         }
+
+        public static bool IsFileLocked(string path)
+        {
+            try
+            {
+                using (Stream stream = new FileStream(path, FileMode.Open))
+                {
+                }
+            }
+            catch (IOException)
+            {
+                return true;
+            }
+
+            return false;
+        }
     }
 }

--- a/CommonControls/Services/PackFileService.cs
+++ b/CommonControls/Services/PackFileService.cs
@@ -489,11 +489,9 @@ namespace CommonControls.Services
 
         public void Save(PackFileContainer pf, string path, bool createBackup)
         {
-            if (File.Exists(path))
+            if (File.Exists(path) && DirectoryHelper.IsFileLocked(path))
             {
-                using (Stream stream = new FileStream(path, FileMode.Open))
-                {
-                }
+                throw new IOException($"Cannot access {path} because another process has locked it, most likely the game.");
             }
 
             if(pf.IsCaPackFile)

--- a/CommonControls/Services/PackFileService.cs
+++ b/CommonControls/Services/PackFileService.cs
@@ -489,6 +489,13 @@ namespace CommonControls.Services
 
         public void Save(PackFileContainer pf, string path, bool createBackup)
         {
+            if (File.Exists(path))
+            {
+                using (Stream stream = new FileStream(path, FileMode.Open))
+                {
+                }
+            }
+
             if(pf.IsCaPackFile)
                 throw new Exception("Can not save ca pack file");
             if (createBackup)


### PR DESCRIPTION
This looks kinda dumb, but it would avoid issues I have with packfiles getting corrupted or changes not saving if I try to save a pack in data while the game is running. If I close the game and then save the pack again it results in corruption or changes made to the pack not saving, no idea why. So we just fail earlier to avoid that.

This will also skip making the _temp pack and a backup.