### PR TITLE
ignore case if checking if a texture path exists

### DIFF
--- a/AssetEditor/Views/MainWindow.xaml.cs
+++ b/AssetEditor/Views/MainWindow.xaml.cs
@@ -92,7 +92,7 @@ namespace AssetEditor.Views
                     if (draggedItem == null)
                         return;
 
-                    var dropTargetNode = dropTargetItem?.DataContext as KitbasherViewModel;
+                    var dropTargetNode = dropTargetItem?.DataContext as IEditorViewModel;
                     if (dropTargetNode == null)
                         return;
 

--- a/CommonControls/PackFileBrowser/PackFileBrowserView.xaml
+++ b/CommonControls/PackFileBrowser/PackFileBrowserView.xaml
@@ -20,7 +20,7 @@
             <RowDefinition/>
         </Grid.RowDefinitions>
 
-        <TextBox KeyboardNavigation.TabIndex="0" KeyboardNavigation.IsTabStop="True"  Grid.Row="0" Text="{Binding Filter.FilterText, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" behaviors:TextBoxExtensions.Watermark="Search filter">
+        <TextBox KeyboardNavigation.TabIndex="0" KeyboardNavigation.IsTabStop="True"  Grid.Row="0" Text="{Binding Filter.FilterText, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay, Delay=350}" behaviors:TextBoxExtensions.Watermark="Search filter">
             <TextBox.Resources>
                 <Style TargetType="{x:Type TextBox}">
                     <Style.Triggers>

--- a/KitbasherEditor/ViewModels/SceneExplorerNodeViews/Rmv2/MaterialGeneralViewModel.cs
+++ b/KitbasherEditor/ViewModels/SceneExplorerNodeViews/Rmv2/MaterialGeneralViewModel.cs
@@ -87,7 +87,7 @@ namespace KitbasherEditor.ViewModels.SceneExplorerNodeViews.Rmv2
 
                 var path = Path.Replace("/", @"\");
 
-                if (!_packfileService.Database.PackFiles.Any(pf => pf.FileList.Any(pair => pair.Key == path)))
+                if (!_packfileService.Database.PackFiles.Any(pf => pf.FileList.Any(pair => pair.Key.Equals(path, StringComparison.OrdinalIgnoreCase))))
                 {
                     var errorMessage = "Invalid Texture Path!" +
                                        (TextureTypeStr == "Mask" ? " This is fine on mask textures." : "");


### PR DESCRIPTION
vanilla often uses `VariantMeshes` in wsmodels texture paths