### PR TITLE
Focus input when creating a new dialog, add clear button to search

### DIFF
--- a/CommonControls/BaseDialogs/TextInputWindow.xaml.cs
+++ b/CommonControls/BaseDialogs/TextInputWindow.xaml.cs
@@ -22,11 +22,16 @@ namespace CommonControls.BaseDialogs
             InitializeComponent();
         }
 
-        public TextInputWindow(string title, string initialValue = "")
+        public TextInputWindow(string title, string initialValue = "", bool focusTextInput = false)
         {
             InitializeComponent();
             Title = title;
             TextValue = initialValue;
+
+            if (focusTextInput)
+            {
+                TextBoxItem.Focus();
+            }
         }
 
         public string TextValue 

--- a/CommonControls/PackFileBrowser/ContextMenuHandler.cs
+++ b/CommonControls/PackFileBrowser/ContextMenuHandler.cs
@@ -1,4 +1,4 @@
-﻿using CommonControls.BaseDialogs;
+using CommonControls.BaseDialogs;
 using CommonControls.Common;
 using CommonControls.FileTypes.PackFiles.Models;
 using CommonControls.Services;
@@ -156,7 +156,7 @@ namespace CommonControls.PackFileBrowser
                 return;
             }
 
-            var window = new TextInputWindow("Create folder");
+            var window = new TextInputWindow("Create folder", default, true);
             if (window.ShowDialog() == true)
                 _selectedNode.Children.Add(new TreeNode(window.TextValue, NodeType.Directory, _selectedNode.FileOwner, _selectedNode));
         }

--- a/CommonControls/PackFileBrowser/PackFileBrowserView.xaml
+++ b/CommonControls/PackFileBrowser/PackFileBrowserView.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="CommonControls.PackFileBrowser.PackFileBrowserView"
+<UserControl x:Class="CommonControls.PackFileBrowser.PackFileBrowserView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -20,7 +20,7 @@
             <RowDefinition/>
         </Grid.RowDefinitions>
 
-        <TextBox KeyboardNavigation.TabIndex="0" KeyboardNavigation.IsTabStop="True"  Grid.Row="0" Text="{Binding Filter.FilterText, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay, Delay=350}" behaviors:TextBoxExtensions.Watermark="Search filter">
+        <TextBox x:Name="FilterTextBoxItem" KeyboardNavigation.TabIndex="0" KeyboardNavigation.IsTabStop="True"  Grid.Column="1" Grid.Row="0" Text="{Binding Filter.FilterText, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay, Delay=350}" behaviors:TextBoxExtensions.Watermark="Search filter">
             <TextBox.Resources>
                 <Style TargetType="{x:Type TextBox}">
                     <Style.Triggers>
@@ -30,8 +30,12 @@
                     </Style.Triggers>
                 </Style>
             </TextBox.Resources>
-
         </TextBox>
+        <Button Click="ClearButtonClick" Command="{Binding ClearTextCommand}" Padding="4,0" HorizontalAlignment="Right" VerticalContentAlignment="Center" Grid.Column="1" Grid.Row="0">
+            <Button.Content>
+                Clear
+            </Button.Content>
+        </Button>
 
         <TreeView  x:Name="tvParameters"
             AllowDrop="True"

--- a/CommonControls/PackFileBrowser/PackFileBrowserView.xaml.cs
+++ b/CommonControls/PackFileBrowser/PackFileBrowserView.xaml.cs
@@ -100,6 +100,11 @@ namespace CommonControls.PackFileBrowser
             }
         }
 
+        private void ClearButtonClick(object sender, RoutedEventArgs e)
+        {
+            FilterTextBoxItem.Focus();
+        }
+
         private void TreeViewItem_PreviewMouseRightButtonDown(object sender, MouseEventArgs e)
         {
             TreeViewItem item = sender as TreeViewItem;

--- a/CommonControls/PackFileBrowser/PackFileBrowserViewModel.cs
+++ b/CommonControls/PackFileBrowser/PackFileBrowserViewModel.cs
@@ -1,4 +1,4 @@
-﻿using CommonControls.Common;
+using CommonControls.Common;
 using CommonControls.FileTypes.PackFiles.Models;
 using CommonControls.Services;
 using CommunityToolkit.Mvvm.Input;
@@ -23,6 +23,7 @@ namespace CommonControls.PackFileBrowser
         public ObservableCollection<TreeNode> Files { get; set; } = new ObservableCollection<TreeNode>();
         public PackFileFilter Filter { get; private set; }
         public ICommand DoubleClickCommand { get; set; }
+        public ICommand ClearTextCommand { get; set; }
 
         TreeNode _selectedItem;
         public TreeNode SelectedItem
@@ -41,6 +42,7 @@ namespace CommonControls.PackFileBrowser
         public PackFileBrowserViewModel(PackFileService packFileService, bool ignoreCaFiles = false)
         {
             DoubleClickCommand = new RelayCommand<TreeNode>(OnDoubleClick);
+            ClearTextCommand = new RelayCommand(OnClearText);
 
             _packFileService = packFileService;
             _packFileService.Database.PackFileContainerLoaded += ReloadTree;
@@ -115,6 +117,11 @@ namespace CommonControls.PackFileBrowser
                     parent = parent.Parent;
                 }
             }
+        }
+
+        protected virtual void OnClearText()
+        {
+            Filter.FilterText = "";
         }
 
         protected virtual void OnDoubleClick(TreeNode node) 


### PR DESCRIPTION
Add two small features to improve usability:

* Add a Clear button on the pack browser sidebar - making it quicker for users to clear filters. Also added an auto focus, but I'm not 100% sure about adding the focus in the codebehind `PackFileBrowserView.xaml.cs`, but I'm a bit unfamiliar with WPF.
* Autofocus the text input when a dialog is opened for a new directory. This is just a constructor arg, so should be easy to apply to different `TextInputWindow` as needed. The default is false, just to remain as backward compatible as possible.