### PR TITLE
MusicTrack, MusicSwitchCntr, MusicSegment, MusicRanSeqCntr, FxCustom, FxShareSet

### DIFF
--- a/CommonControls/FileTypes/Sound/WWise/Hirc/HircParser.cs
+++ b/CommonControls/FileTypes/Sound/WWise/Hirc/HircParser.cs
@@ -70,6 +70,12 @@ namespace CommonControls.FileTypes.Sound.WWise.Hirc
             instance.RegisterHirc(HircType.SequenceContainer, () => new V136.CAkRanSeqCntr_v136());
             instance.RegisterHirc(HircType.LayerContainer, () => new V136.CAkLayerCntr_v136());
             instance.RegisterHirc(HircType.Dialogue_Event, () => new V136.CAkDialogueEvent_v136());
+            instance.RegisterHirc(HircType.Music_Track, () => new V136.CAkMusicTrack_v136());
+            instance.RegisterHirc(HircType.Music_Segment, () => new V136.CAkMusicSegment_v136());
+            instance.RegisterHirc(HircType.Music_Random_Sequence, () => new V136.CAkMusicRanSeqCntr_v136());
+            instance.RegisterHirc(HircType.Music_Switch, () => new V136.CAkMusicSwitchCntr_v136());
+            instance.RegisterHirc(HircType.FxCustom, () => new V136.CAkFxCustom_v136());
+            instance.RegisterHirc(HircType.FxShareSet, () => new V136.CAkFxShareSet_v136());
             return instance;
         }
 

--- a/CommonControls/FileTypes/Sound/WWise/Hirc/V136/CAkFxCustom_v136.cs
+++ b/CommonControls/FileTypes/Sound/WWise/Hirc/V136/CAkFxCustom_v136.cs
@@ -1,0 +1,127 @@
+﻿using CommonControls.FileTypes.Sound.WWise;
+using CommonControls.FileTypes.Sound.WWise.Hirc;
+using Filetypes.ByteParsing;
+using System;
+using System.Collections.Generic;
+
+namespace CommonControls.FileTypes.Sound.WWise.Hirc.V136
+{
+    public class CAkFxCustom_v136 : HircItem
+    {
+        public uint plugin_id { get; set; }
+        public AkPluginParam AkPluginParam { get; set; }
+        public List<AkMediaMap> mediaList { get; set; } = new List<AkMediaMap>();
+        public InitialRTPC InitialRTPC { get; set; }
+        public StateChunk StateChunk { get; set; }
+        public List<PluginPropertyValue> propertyValuesList { get; set; } = new List<PluginPropertyValue>();
+
+        protected override void CreateSpesificData(ByteChunk chunk)
+        {
+            //contains the plugin type and company id (CA doesn't have one apparently)
+            plugin_id = chunk.ReadUInt32();
+
+            var uSize = chunk.ReadUInt32();
+            AkPluginParam = AkPluginParam.Create(chunk, plugin_id, uSize);
+
+            var uNumBankData = chunk.ReadByte();
+            for (int i = 0; i < uNumBankData; i++)
+                mediaList.Add(AkMediaMap.Create(chunk));
+
+            InitialRTPC = InitialRTPC.Create(chunk);
+            StateChunk = StateChunk.Create(chunk);
+
+            var numValues = chunk.ReadShort();
+            for (int i = 0; i < numValues; i++)
+                propertyValuesList.Add(PluginPropertyValue.Create(chunk));
+
+        }
+    }
+
+    public class AkMediaMap
+    {
+        public byte index { get; set; }
+        public uint sourceId { get; set; }
+
+        public static AkMediaMap Create(ByteChunk chunk)
+        {
+            var instance = new AkMediaMap();
+
+            instance.index = chunk.ReadByte();
+            instance.sourceId = chunk.ReadUInt32();
+
+            return instance;
+        }
+    }
+
+    public class PluginPropertyValue
+    {
+        public uint propertyId { get; set; }
+        public byte rtpcAccum { get; set; }
+        public float fValue { get; set; }
+
+        public static PluginPropertyValue Create(ByteChunk chunk)
+        {
+            var instance = new PluginPropertyValue();
+
+            instance.propertyId = chunk.ReadUInt32();
+            instance.rtpcAccum = chunk.ReadByte();
+            instance.fValue = chunk.ReadSingle();
+
+            return instance;
+        }
+    }
+
+    public class CAkFxSrcSilenceParams : AkPluginParam
+    {
+        public float fDuration { get; set; }
+        public float fRandomizedLengthMinus { get; set; }
+        public float fRandomizedLengthPlus { get; set; }
+
+        public static CAkFxSrcSilenceParams Create(ByteChunk chunk, uint uSize)
+        {
+            var instance = new CAkFxSrcSilenceParams();
+            instance.fDuration = chunk.ReadSingle();
+            instance.fRandomizedLengthMinus = chunk.ReadSingle();
+            instance.fRandomizedLengthPlus = chunk.ReadSingle();
+            return instance;
+        }
+    }
+
+    public class AkPluginParam
+    {
+        public List<byte> pParamBlock { get; set; } = new List<byte>();
+        //used for default case, "gap" of bytes
+
+        public static AkPluginParam Create(ByteChunk chunk, uint plugin_id, uint uSize)
+        {
+            //Only SrcSilence is used for WH3... maybe...
+            //Actually the default case would take care of any of them, so ehhh
+            switch (plugin_id)
+            {
+                //case 0x00640002: return CAkFxSrcSineParams.Create(chunk, uSize);
+                case 0x00650002: return CAkFxSrcSilenceParams.Create(chunk, uSize);
+                //case 0x00660002: return CAkToneGenParams.Create(chunk, uSize);
+                //case 0x00690003: return CAkParameterEQFXParams.Create(chunk, uSize);
+                //case 0x006A0003: return CAkDelayFXParams.Create(chunk, uSize);
+                //case 0x006E0003: return CAkPeakLimiterFXParams.Create(chunk, uSize);
+                //case 0x00730003: return CAkFDNReverbFXParams.Create(chunk, uSize);
+                //case 0x00760003: return CAkRoomVerbFXParams.Create(chunk, uSize);
+                //case 0x007D0003: return CAkFlangerFXParams.Create(chunk, uSize);
+                //case 0x007E0003: return CAkGuitarDistortionFXParams.Create(chunk, uSize);
+                //case 0x007F0003: return CAkConvolutionReverbFXParams.Create(chunk, uSize);
+                //case 0x00810003: return CAkMeterFXParams.Create(chunk, uSize);
+                //case 0x00870003: return CAkStereoDelayFXParams.Create(chunk, uSize);
+                //case 0x008B0003: return CAkGainFXParams.Create(chunk, uSize);
+                //case 0x00940002: return CAkSynthOneParams.Create(chunk, uSize);
+                //case 0x00C80002: return CAkFxSrcAudioInputParams.Create(chunk, uSize);
+                //case 0x00041033: return iZTrashDelayFXParams.Create(chunk, uSize);
+                default:
+                    //Default "gap"
+                    var instance = new AkPluginParam();
+                    for (int i = 0; i < uSize; i++)
+                        instance.pParamBlock.Add(chunk.ReadByte());
+                    return instance;
+            }
+        }
+    }
+}

--- a/CommonControls/FileTypes/Sound/WWise/Hirc/V136/CAkFxShareSet_v136.cs
+++ b/CommonControls/FileTypes/Sound/WWise/Hirc/V136/CAkFxShareSet_v136.cs
@@ -1,0 +1,41 @@
+﻿using CommonControls.FileTypes.Sound.WWise;
+using CommonControls.FileTypes.Sound.WWise.Hirc;
+using Filetypes.ByteParsing;
+using System;
+using System.Collections.Generic;
+
+namespace CommonControls.FileTypes.Sound.WWise.Hirc.V136
+{
+    //Seems like it's exactly the same as FxCustom...
+    //Not sure if there's a fancy C# way of doing things, but I just copy+pasted it below
+    public class CAkFxShareSet_v136 : HircItem
+    { 
+        public uint plugin_id { get; set; }
+        public AkPluginParam AkPluginParam { get; set; }
+        public List<AkMediaMap> mediaList { get; set; } = new List<AkMediaMap>();
+        public InitialRTPC InitialRTPC { get; set; }
+        public StateChunk StateChunk { get; set; }
+        public List<PluginPropertyValue> propertyValuesList { get; set; } = new List<PluginPropertyValue>();
+
+        protected override void CreateSpesificData(ByteChunk chunk)
+        {
+            //contains the plugin type and company id (CA doesn't have one apparently)
+            plugin_id = chunk.ReadUInt32();
+
+            var uSize = chunk.ReadUInt32();
+            AkPluginParam = AkPluginParam.Create(chunk, plugin_id, uSize);
+
+            var uNumBankData = chunk.ReadByte();
+            for (int i = 0; i < uNumBankData; i++)
+                mediaList.Add(AkMediaMap.Create(chunk));
+
+            InitialRTPC = InitialRTPC.Create(chunk);
+            StateChunk = StateChunk.Create(chunk);
+
+            var numValues = chunk.ReadShort();
+            for (int i = 0; i < numValues; i++)
+                propertyValuesList.Add(PluginPropertyValue.Create(chunk));
+
+        }
+    }
+}

--- a/CommonControls/FileTypes/Sound/WWise/Hirc/V136/CAkMusicRanSeqCntr_v136.cs
+++ b/CommonControls/FileTypes/Sound/WWise/Hirc/V136/CAkMusicRanSeqCntr_v136.cs
@@ -1,0 +1,228 @@
+﻿using CommonControls.FileTypes.Sound.WWise;
+using CommonControls.FileTypes.Sound.WWise.Hirc;
+using Filetypes.ByteParsing;
+using System;
+using System.Collections.Generic;
+
+namespace CommonControls.FileTypes.Sound.WWise.Hirc.V136
+{
+    public class CAkMusicRanSeqCntr_v136 : HircItem
+    {
+
+        public MusicTransNodeParams MusicTransNodeParams { get; set; }
+
+        public List<AkMusicRanSeqPlaylistItem> pPlayList { get; set; } = new List<AkMusicRanSeqPlaylistItem>();
+
+
+        protected override void CreateSpesificData(ByteChunk chunk)
+        {
+            MusicTransNodeParams = MusicTransNodeParams.Create(chunk);
+
+            //this is like a tree, numPlaylistItems is the total in the tree... I think
+            var numPlaylistItems = chunk.ReadUInt32();
+            //and the root always has 1, again I think...
+            //for (int i = 0; i < numPlaylistItems; i++)
+            pPlayList.Add(AkMusicRanSeqPlaylistItem.Create(chunk));
+        }
+    }
+    public class MusicTransNodeParams
+    {
+        public MusicNodeParams MusicNodeParams { get; set; }
+        public List<AkMusicTransitionRule> pPlayList { get; set; } = new List<AkMusicTransitionRule>();
+       
+        public static MusicTransNodeParams Create(ByteChunk chunk)
+        {
+            var instance = new MusicTransNodeParams();
+
+            instance.MusicNodeParams = MusicNodeParams.Create(chunk);
+
+            var numRules = chunk.ReadUInt32();
+            for (int i = 0; i < numRules; i++)
+                instance.pPlayList.Add(AkMusicTransitionRule.Create(chunk));
+
+            return instance;
+        }
+    }
+
+    public class AkMusicTransitionRule
+    {
+        public uint uNumSrc { get; set; }
+        public List<uint> srcIDList { get; set; } = new List<uint>();
+
+        public uint uNumDst { get; set; }
+        public List<uint> dstIDList { get; set; } = new List<uint>();
+        public AkMusicTransSrcRule AkMusicTransSrcRule { get; set; }
+        public AkMusicTransDstRule AkMusicTransDstRule { get; set; }
+
+        public uint ulStateGroupID_custom { get; set; }
+        public uint ulStateID_custom { get; set; }
+        public byte AllocTransObjectFlag { get; set; }
+        public AkMusicTransitionObject AkMusicTransitionObject { get; set; }
+
+        public static AkMusicTransitionRule Create(ByteChunk chunk)
+        {
+            var instance = new AkMusicTransitionRule();
+
+            var uNumSrc = chunk.ReadUInt32();
+            for (int i = 0; i < uNumSrc; i++)
+                instance.srcIDList.Add(chunk.ReadUInt32());
+
+            var uNumDst = chunk.ReadUInt32();
+            for (int i = 0; i < uNumDst; i++)
+                instance.dstIDList.Add(chunk.ReadUInt32());
+
+            instance.AkMusicTransSrcRule = AkMusicTransSrcRule.Create(chunk);
+
+            instance.AkMusicTransDstRule = AkMusicTransDstRule.Create(chunk);
+
+            
+            instance.ulStateGroupID_custom = chunk.ReadUInt32();
+            instance.ulStateID_custom = chunk.ReadUInt32();
+
+            var AllocTransObjectFlag = chunk.ReadByte();
+            var has_transobj = AllocTransObjectFlag != 0;
+            if (has_transobj)
+                instance.AkMusicTransitionObject = AkMusicTransitionObject.Create(chunk);
+
+            return instance;
+        }
+    }
+
+    public class AkMusicTransitionObject
+    {
+        public int segmentID { get; set; }
+        public AkMusicFade fadeInParams { get; set; }
+        public AkMusicFade fadeOutParams { get; set; }
+        public byte bPlayPreEntry { get; set; }
+        public byte bPlayPostExit { get; set; }
+
+        public static AkMusicTransitionObject Create(ByteChunk chunk)
+        {
+            var instance = new AkMusicTransitionObject();
+
+            instance.segmentID = chunk.ReadInt32();
+            instance.fadeInParams = AkMusicFade.Create(chunk);
+            instance.fadeOutParams = AkMusicFade.Create(chunk);
+
+            instance.bPlayPreEntry = chunk.ReadByte();
+            instance.bPlayPostExit = chunk.ReadByte();
+
+            return instance;
+        }
+    }
+
+    public class AkMusicFade
+    {
+        public int transitionTime { get; set; }
+        public uint eFadeCurve { get; set; }
+        public int iFadeOffset { get; set; }
+
+
+        public static AkMusicFade Create(ByteChunk chunk)
+        {
+            var instance = new AkMusicFade();
+
+            instance.transitionTime = chunk.ReadInt32();
+            instance.eFadeCurve = chunk.ReadUInt32();
+            instance.iFadeOffset = chunk.ReadInt32();
+
+            return instance;
+        }
+    }
+
+    public class AkMusicTransSrcRule
+    {
+        public int transitionTime { get; set; }
+        public uint eFadeCurve { get; set; }
+        public int iFadeOffset { get; set; }
+        public uint eSyncType { get; set; }
+        public uint uCueFilterHash { get; set; }
+        public byte bPlayPostExit { get; set; }
+
+
+        public static AkMusicTransSrcRule Create(ByteChunk chunk)
+        {
+            var instance = new AkMusicTransSrcRule();
+
+            instance.transitionTime = chunk.ReadInt32();
+            instance.eFadeCurve = chunk.ReadUInt32();
+            instance.iFadeOffset = chunk.ReadInt32();
+            instance.eSyncType = chunk.ReadUInt32();
+            instance.uCueFilterHash = chunk.ReadUInt32();
+            instance.bPlayPostExit = chunk.ReadByte();
+
+            return instance;
+        }
+    }
+
+    public class AkMusicTransDstRule
+    {
+
+        public int transitionTime { get; set; }
+        public uint eFadeCurve { get; set; }
+        public int iFadeOffset { get; set; }
+        public uint uCueFilterHash { get; set; }
+        public uint uJumpToID { get; set; }
+        public ushort eJumpToType { get; set; }
+        public ushort eEntryType { get; set; }
+        public byte bPlayPreEntry { get; set; }
+        public byte bDestMatchSourceCueName { get; set; }
+
+
+        public static AkMusicTransDstRule Create(ByteChunk chunk)
+        {
+            var instance = new AkMusicTransDstRule();
+
+            instance.transitionTime = chunk.ReadInt32();
+            instance.eFadeCurve = chunk.ReadUInt32();
+            instance.iFadeOffset = chunk.ReadInt32();
+            instance.uCueFilterHash = chunk.ReadUInt32();
+            instance.uJumpToID = chunk.ReadUInt32();
+            instance.eJumpToType = chunk.ReadUShort();
+            instance.eEntryType = chunk.ReadUShort();
+            instance.bPlayPreEntry = chunk.ReadByte();
+            instance.bDestMatchSourceCueName = chunk.ReadByte();
+
+            return instance;
+        }
+    }
+
+    public class AkMusicRanSeqPlaylistItem
+    {
+        public uint SegmentID { get; set; }
+        public int playlistItemID { get; set; }
+        public uint eRSType { get; set; }
+        public short Loop { get; set; }
+        public short LoopMin { get; set; }
+        public short LoopMax { get; set; }
+        public uint Weight { get; set; }
+        public ushort wAvoidRepeatCount { get; set; }
+        public byte bIsUsingWeight { get; set; }
+        public byte bIsShuffle { get; set; }
+
+        public List<AkMusicRanSeqPlaylistItem> pPlayList { get; set; } = new List<AkMusicRanSeqPlaylistItem>();
+
+
+        public static AkMusicRanSeqPlaylistItem Create(ByteChunk chunk)
+        {
+            var instance = new AkMusicRanSeqPlaylistItem();
+
+            instance.SegmentID = chunk.ReadUInt32();
+            instance.playlistItemID = chunk.ReadInt32();
+            var NumChildren = chunk.ReadUInt32();
+            instance.eRSType = chunk.ReadUInt32();
+            instance.Loop = chunk.ReadShort();
+            instance.LoopMin = chunk.ReadShort();
+            instance.LoopMax = chunk.ReadShort();
+            instance.Weight = chunk.ReadUInt32();
+            instance.wAvoidRepeatCount = chunk.ReadUShort();
+            instance.bIsUsingWeight = chunk.ReadByte();
+            instance.bIsShuffle = chunk.ReadByte();
+
+            for (int i = 0; i < NumChildren; i++)
+                instance.pPlayList.Add(AkMusicRanSeqPlaylistItem.Create(chunk));
+
+            return instance;
+        }
+    }
+}

--- a/CommonControls/FileTypes/Sound/WWise/Hirc/V136/CAkMusicSegment_v136.cs
+++ b/CommonControls/FileTypes/Sound/WWise/Hirc/V136/CAkMusicSegment_v136.cs
@@ -1,0 +1,124 @@
+﻿using CommonControls.FileTypes.Sound.WWise;
+using CommonControls.FileTypes.Sound.WWise.Hirc;
+using Filetypes.ByteParsing;
+using System;
+using System.Collections.Generic;
+
+namespace CommonControls.FileTypes.Sound.WWise.Hirc.V136
+{
+    public class CAkMusicSegment_v136 : HircItem
+    {
+        
+        public MusicNodeParams MusicNodeParams { get; set; }
+        public double fDuration { get; set; }
+        public List<AkMusicMarkerWwise> pArrayMarkersList { get; set; } = new List<AkMusicMarkerWwise>();
+
+
+        protected override void CreateSpesificData(ByteChunk chunk)
+        {
+            MusicNodeParams = MusicNodeParams.Create(chunk);
+
+            fDuration = chunk.ReadInt64(); //chunk.ReadDouble();
+
+            var ulNumMarkers = chunk.ReadUInt32();
+            for (int i = 0; i < ulNumMarkers; i++)
+                pArrayMarkersList.Add(AkMusicMarkerWwise.Create(chunk));
+        }
+    }
+
+    public class AkMusicMarkerWwise
+    {
+        public uint id { get; set; }
+        public double fPosition { get; set; }
+
+        //see below
+        //public string pMarkerName { get; set; }
+        public List<byte> pMarkerName { get; set; } = new List<byte>();
+
+        public static AkMusicMarkerWwise Create(ByteChunk chunk)
+        {
+            var instance = new AkMusicMarkerWwise();
+            instance.id = chunk.ReadUInt32();
+            instance.fPosition = chunk.ReadInt64(); //chunk.ReadDouble();
+
+            //instance.pMarkerName = chunk.ReadString();
+            //The above wasn't working because uStringSize is an uint32, yet the ReadString was trying to read it as a uint16
+            //So instead I just made it read the raw bytes, stored in a list
+            var uStringSize = chunk.ReadUInt32();
+            for (int i = 0; i < uStringSize; i++)
+                instance.pMarkerName.Add(chunk.ReadByte());
+
+            return instance;
+        }
+    }
+
+    public class MusicNodeParams
+    {
+        public byte uFlags { get; set; }
+        public NodeBaseParams NodeBaseParams { get; set; }
+        public Children Children { get; set; }
+        public AkMeterInfo AkMeterInfo { get; set; }
+        public byte bMeterInfoFlag { get; set; }
+        public List<CAkStinger> pStingersList { get; set; } = new List<CAkStinger>();
+
+        public static MusicNodeParams Create(ByteChunk chunk)
+        {
+            var instance = new MusicNodeParams();
+            instance.uFlags = chunk.ReadByte();
+            instance.NodeBaseParams = NodeBaseParams.Create(chunk);
+            instance.Children = Children.Create(chunk);
+            instance.AkMeterInfo = AkMeterInfo.Create(chunk);
+            instance.bMeterInfoFlag = chunk.ReadByte();
+
+            var NumStingers = chunk.ReadUInt32();
+            for (int i = 0; i < NumStingers; i++)
+                instance.pStingersList.Add(CAkStinger.Create(chunk));
+
+            return instance;
+        }
+    }
+
+    public class AkMeterInfo
+    {
+        public double fGridPeriod { get; set; }
+        public double fGridOffset { get; set; }
+        public float fTempo { get; set; }
+        public byte uTimeSigNumBeatsBar { get; set; }
+        public byte uTimeSigBeatValue { get; set; }
+
+        public static AkMeterInfo Create(ByteChunk chunk)
+        {
+            var instance = new AkMeterInfo();
+            instance.fGridPeriod = chunk.ReadInt64(); //chunk.ReadDouble();
+            instance.fGridOffset = chunk.ReadInt64(); //chunk.ReadDouble();
+            instance.fTempo = chunk.ReadSingle();
+            instance.uTimeSigNumBeatsBar = chunk.ReadByte();
+            instance.uTimeSigBeatValue = chunk.ReadByte();
+
+            return instance;
+        }
+    }
+
+    public class CAkStinger
+    {
+        public uint TriggerID { get; set; }
+        public uint SegmentID { get; set; }
+        public uint SyncPlayAt { get; set; }
+        public uint uCueFilterHash { get; set; }
+        public int DontRepeatTime { get; set; }
+        public uint numSegmentLookAhead { get; set; }
+
+        public static CAkStinger Create(ByteChunk chunk)
+        {
+            var instance = new CAkStinger();
+            instance.TriggerID = chunk.ReadUInt32();
+            instance.SegmentID = chunk.ReadUInt32();
+            instance.SyncPlayAt = chunk.ReadUInt32();
+            instance.uCueFilterHash = chunk.ReadUInt32();
+            instance.DontRepeatTime = chunk.ReadInt32();
+            instance.numSegmentLookAhead = chunk.ReadUInt32();
+
+            return instance;
+        }
+    }
+}

--- a/CommonControls/FileTypes/Sound/WWise/Hirc/V136/CAkMusicSwitchCntr_v136.cs
+++ b/CommonControls/FileTypes/Sound/WWise/Hirc/V136/CAkMusicSwitchCntr_v136.cs
@@ -1,0 +1,34 @@
+﻿using CommonControls.FileTypes.Sound.WWise;
+using CommonControls.FileTypes.Sound.WWise.Hirc;
+using Filetypes.ByteParsing;
+using System;
+using System.Collections.Generic;
+
+namespace CommonControls.FileTypes.Sound.WWise.Hirc.V136
+{
+    public class CAkMusicSwitchCntr_v136 : HircItem
+    {
+        
+        public MusicTransNodeParams MusicTransNodeParams { get; set; }
+        public byte bIsContinuePlayback { get; set; }
+
+        public uint uTreeDepth;
+        public ArgumentList ArgumentList;
+        public uint uTreeDataSize;
+        public byte uMode;
+        public AkDecisionTree AkDecisionTree;
+
+
+        protected override void CreateSpesificData(ByteChunk chunk)
+        {
+            MusicTransNodeParams = MusicTransNodeParams.Create(chunk);
+            bIsContinuePlayback = chunk.ReadByte();
+
+            uTreeDepth = chunk.ReadUInt32();
+            ArgumentList = new ArgumentList(chunk, uTreeDepth);
+            uTreeDataSize = chunk.ReadUInt32();
+            uMode = chunk.ReadByte();
+            AkDecisionTree = new AkDecisionTree(chunk, uTreeDepth, Size);
+        }
+    }
+}

--- a/CommonControls/FileTypes/Sound/WWise/Hirc/V136/CAkMusicTrack_v136.cs
+++ b/CommonControls/FileTypes/Sound/WWise/Hirc/V136/CAkMusicTrack_v136.cs
@@ -1,0 +1,99 @@
+﻿using CommonControls.FileTypes.Sound.WWise;
+using CommonControls.FileTypes.Sound.WWise.Hirc;
+using Filetypes.ByteParsing;
+using System;
+using System.Collections.Generic;
+
+namespace CommonControls.FileTypes.Sound.WWise.Hirc.V136
+{
+    public class CAkMusicTrack_v136 : HircItem
+    {
+        
+        public byte uFlags { get; set; }
+
+        public List<AkBankSourceData> pSourceList { get; set; } = new List<AkBankSourceData>();
+
+        public List<AkTrackSrcInfo> pPlaylistList { get; set; } = new List<AkTrackSrcInfo>();
+
+        public uint numSubTrack { get; set; }
+
+        public List<AkClipAutomation> pItemsList { get; set; } = new List<AkClipAutomation>();
+
+        public NodeBaseParams NodeBaseParams { get; set; }
+
+        public byte eTrackType { get; set; }
+        public int iLookAheadTime { get; set; }
+
+
+        protected override void CreateSpesificData(ByteChunk chunk)
+        {
+            uFlags = chunk.ReadByte();
+
+            var numSources = chunk.ReadUInt32();
+            for (int i = 0; i < numSources; i++)
+                pSourceList.Add(AkBankSourceData.Create(chunk));
+
+            var numPlaylistItem = chunk.ReadUInt32();
+            for (int i = 0; i < numPlaylistItem; i++)
+                pPlaylistList.Add(AkTrackSrcInfo.Create(chunk));
+
+            if (numPlaylistItem > 0)
+                numSubTrack = chunk.ReadUInt32();
+
+            var numClipAutomationItem = chunk.ReadUInt32();
+            for (int i = 0; i < numClipAutomationItem; i++)
+                pItemsList.Add(AkClipAutomation.Create(chunk));
+
+            NodeBaseParams = NodeBaseParams.Create(chunk);
+
+            eTrackType = chunk.ReadByte();
+
+            iLookAheadTime = chunk.ReadInt32();
+        }
+    }
+
+    public class AkTrackSrcInfo
+    {
+        public uint trackID { get; set; }
+        public uint sourceID { get; set; }
+        public uint eventID { get; set; }
+        public double fPlayAt { get; set; }
+        public double fBeginTrimOffset { get; set; }
+        public double fEndTrimOffset { get; set; }
+        public double fSrcDuration { get; set; }
+
+        public static AkTrackSrcInfo Create(ByteChunk chunk)
+        {
+            var output = new AkTrackSrcInfo()
+            {
+                trackID = chunk.ReadUInt32(),
+                sourceID = chunk.ReadUInt32(),
+                eventID = chunk.ReadUInt32(),
+                fPlayAt = chunk.ReadInt64(), //chunk.ReadDouble()
+                fBeginTrimOffset = chunk.ReadInt64(), //chunk.ReadDouble()
+                fEndTrimOffset = chunk.ReadInt64(), //chunk.ReadDouble()
+                fSrcDuration = chunk.ReadInt64(), //chunk.ReadDouble()
+            };
+            return output;
+        }
+    }
+
+    public class AkClipAutomation
+    {
+        public uint uClipIndex { get; set; }
+        public uint eAutoType { get; set; }
+        public List<AkRTPCGraphPoint> pRTPCMgr { get; set; } = new List<AkRTPCGraphPoint>();
+
+        public static AkClipAutomation Create(ByteChunk chunk)
+        {
+            var instance = new AkClipAutomation();
+            instance.uClipIndex = chunk.ReadUInt32();
+            instance.eAutoType = chunk.ReadUInt32();
+            var uNumPoints = chunk.ReadUInt32();
+            for (int i = 0; i < uNumPoints; i++)
+                instance.pRTPCMgr.Add(AkRTPCGraphPoint.Create(chunk));
+
+            return instance;
+        }
+    }
+}


### PR DESCRIPTION
MusicTrack, MusicSwitchCntr, MusicSegment, MusicRanSeqCntr, FxCustom, FxShareSet

Note that several double precision floats were decoded as uint64's in MusicTrack and MusicSegment.
And MusicSegment had a string "pMarkerName" whose length was given as an int32 rather than int16, so I just decoded that as a list of bytes.

Also FxShareSet ended up being the exact same as FxCustom, no idea what's up with that or if it even matters.